### PR TITLE
network partition implemented

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - "6500:5000"
     networks:
       - raft-network
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   node2:
     build: .
@@ -19,6 +22,9 @@ services:
       - "6501:5000"
     networks:
       - raft-network
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   node3:
     build: .
@@ -29,6 +35,9 @@ services:
       - "6502:5000"
     networks:
       - raft-network
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
 networks:
   raft-network:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ certifi==2024.8.30
 charset-normalizer==3.4.0
 click==8.1.7
 Flask==3.0.3
+docker==7.1.0
 idna==3.10
 importlib_metadata==8.5.0
 itsdangerous==2.2.0

--- a/servers/candidate.py
+++ b/servers/candidate.py
@@ -34,7 +34,7 @@ class CandidateState:
         """Create a VoteRequestMessage, send it to all peers, and delegate response processing."""
         # Create VoteRequestMessage based on the last log index and term
         last_log_index = len(self.node.message_log) - 1 if len(self.node.message_log) > 0 else -1
-        last_log_term = self.node.message_log[last_log_index].term if last_log_index >= 0 else -1
+        last_log_term = self.node.message_log[last_log_index]["term"] if last_log_index >= 0 else -1
 
         vote_request = VoteRequestMessage(
             sender_id=self.node.node_id,


### PR DESCRIPTION
This PR implements shutting down a node using docker to simulate a network partition for 30 seconds. Currently, the node does not respawn after the intended 30 seconds. 

